### PR TITLE
Fixed Hex.neighbours missing a tile

### DIFF
--- a/lib/hex.ex
+++ b/lib/hex.ex
@@ -177,11 +177,12 @@ defmodule HexGrid.Hex do
   %Hex{q: -1, r: 1, s: 0},
   %Hex{q: -1, r: 0, s: 1},
   %Hex{q: 0, r: -1, s: 1}
+  %Hex{q: 1, r: -1, s: 0}
   ]
   """
   @spec neighbours(t) :: [t]
   def neighbours(hex) do
-    Enum.map(1..5, fn (x) -> neighbour(hex, x) end)
+    Enum.map(0..5, fn (x) -> neighbour(hex, x) end)
   end
 
   @doc ~S"""


### PR DESCRIPTION
Really screwed with my pathfinding. Turns out the lower-left tile was missing! :smile: 

![image](https://user-images.githubusercontent.com/4090519/62519833-e0ffd080-b81b-11e9-8aa2-76fbb5089ece.png)

Also, thanks for this library!